### PR TITLE
created StockRecordSerializer

### DIFF
--- a/src/main/java/StockRecordSerializer.java
+++ b/src/main/java/StockRecordSerializer.java
@@ -1,0 +1,24 @@
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Serializer;
+import java.util.Map;
+
+public class StockRecordSerializer implements Serializer<StockRecord> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public byte[] serialize(String topic, StockRecord data) {
+        try {
+            return objectMapper.writeValueAsBytes(data);
+        } catch (Exception e) {
+            throw new RuntimeException("Error serializing StockRecord", e);
+        }
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public void close() {
+    }
+}


### PR DESCRIPTION
# Summary
In order for the StockRecords to be used by the StreamProducer in Kafka they have to have serialization class.