### PR TITLE
api image builds properly

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . . 
 
 # expose the port Flask will run on
-EXPOSE 5000
+EXPOSE 5335
 
 # run the app
 CMD ["python", "api.py"]

--- a/api/api.py
+++ b/api/api.py
@@ -41,4 +41,4 @@ def hello_world():
 
 
 if __name__ == '__main__':
-    app.run(debug=True, host='localhost', port=5335)
+    app.run(debug=True, host='0.0.0.0', port=5335)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,7 +6,7 @@ Flask-SQLAlchemy==3.1.1
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
-psycopg2==2.9.10
+psycopg2-binary==2.9.10
 SQLAlchemy==2.0.41
 typing_extensions==4.14.1
 Werkzeug==3.1.3


### PR DESCRIPTION
# Summary
- replaced ``psycopg2`` with ``psycopg2-binary`` to avoid build issues when using Docker
- changed the port in the Dockerfile to be ``5335``
- modified the Flask host to be ``0.0.0.0`` so the frontend container can access it