### PR TITLE
Update platform

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -12,7 +12,6 @@ logging.basicConfig(level=logging.DEBUG)
 app = Flask(__name__)
 socketio = SocketIO(
     app, cors_allowed_origins=os.getenv("API_ALLOWED_ORIGINS"), async_mode="eventlet")  # type:ignore
-CORS(app)
 
 
 def get_resources():

--- a/bin/build-and-push.sh
+++ b/bin/build-and-push.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Backend services
+docker compose -f docker-compose.server.yml build
+docker push jackyoungdev/backend-kafka:0.1
+docker push jackyoungdev/kafka-backend-api:0.1
+
+# Frontend
+docker compose -f docker-compose.client.yml build
+docker push jackyoungdev/kafka-dashboard-client:0.1

--- a/client/kafka-dashboard-client/package-lock.json
+++ b/client/kafka-dashboard-client/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/x-charts": "^8.9.2",
         "dayjs": "^1.11.13",
         "loglevel": "^1.9.2",
+        "process": "^0.11.10",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "socket.io-client": "^4.8.1"
@@ -3701,6 +3702,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/prop-types": {

--- a/client/kafka-dashboard-client/package.json
+++ b/client/kafka-dashboard-client/package.json
@@ -17,6 +17,7 @@
     "@mui/x-charts": "^8.9.2",
     "dayjs": "^1.11.13",
     "loglevel": "^1.9.2",
+    "process": "^0.11.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "socket.io-client": "^4.8.1"

--- a/client/kafka-dashboard-client/src/hooks/socket.ts
+++ b/client/kafka-dashboard-client/src/hooks/socket.ts
@@ -3,5 +3,5 @@ import {io, Socket} from "socket.io-client"
 
 const URL = process.env.REACT_APP_API_URL
 export const socket : Socket = io(URL, {
-    transports: ['websocket']
+    transports: ['polling','websocket']
 });

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -10,6 +10,7 @@ services:
     env_file:
       - ./client/kafka-dashboard-client/src/.env
     image: jackyoungdev/kafka-dashboard-client:0.1
+    platform: linux/amd64
 networks:
   kafka_dashboard:
     external: true

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -51,10 +51,14 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_CREATE_TOPICS: "stock-records:1:1"
       ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_LOG_DIRS: /kafka-logs
+      KAFKA_LOG_RETENTION_MS: 1000
     depends_on:
       - zookeeper
     networks:
       - kafka_dashboard
+    tmpfs:
+      - /kafka-logs
 
   kafka-app:
     build:

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: ./api
       dockerfile: Dockerfile
+    platform: linux/amd64
     image: jackyoungdev/kafka-backend-api:0.1
     ports:
       - "5335:5335"
@@ -28,21 +29,30 @@ services:
     networks:
       - kafka_dashboard
 
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    ports:
+      - "2181:2181"
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_PORT: 2181
+      ZOO_SERVERS: server.1=zookeeper:2888:3888
+    networks:
+      - kafka_dashboard
+
   kafka-broker:
-    image: bitnami/kafka:3.7
+    image: wurstmeister/zookeeper:latest
     ports:
       - "9092:9092"
     environment:
-      KAFKA_CFG_NODE_ID: 0
-      KAFKA_CFG_PROCESS_ROLES: broker,controller
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@kafka-broker:9093
-      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka-broker:9092
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-broker:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_CREATE_TOPICS: "stock-records:1:1"
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+    depends_on:
+      - zookeeper
     networks:
       - kafka_dashboard
 
@@ -50,6 +60,7 @@ services:
     build:
       context: ./kafka
       dockerfile: Dockerfile
+    platform: linux/amd64
     image: jackyoungdev/backend-kafka:0.1
     depends_on:
       - kafka-broker


### PR DESCRIPTION
I ended up doing a lot more on this branch this I had anticipated so here are the changes:
- the docker compose files now explicitly state they are building for ``linux/amd64`` platform - allows images to run on EC2 instance
- the socket initially polls until it can establish the websocket
- changed kafka brokers for EC2 compatibility 
   - The new broker requires the kafka manager ``zookeeper`` so that has been added to the compose file as well
- wrote a simple script to build and push services to docker hub


Why did I do all of this? 
- These changes allow the backend (api + db + kafka) to run on my EC2 instance