### PR TITLE
use meta env

### DIFF
--- a/client/kafka-dashboard-client/package-lock.json
+++ b/client/kafka-dashboard-client/package-lock.json
@@ -15,7 +15,6 @@
         "@mui/x-charts": "^8.9.2",
         "dayjs": "^1.11.13",
         "loglevel": "^1.9.2",
-        "process": "^0.11.10",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "socket.io-client": "^4.8.1"
@@ -30,6 +29,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "process": "^0.11.10",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4"
@@ -3708,6 +3708,7 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"

--- a/client/kafka-dashboard-client/package.json
+++ b/client/kafka-dashboard-client/package.json
@@ -17,7 +17,6 @@
     "@mui/x-charts": "^8.9.2",
     "dayjs": "^1.11.13",
     "loglevel": "^1.9.2",
-    "process": "^0.11.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "socket.io-client": "^4.8.1"
@@ -32,6 +31,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "process": "^0.11.10",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4"

--- a/client/kafka-dashboard-client/src/hooks/socket.ts
+++ b/client/kafka-dashboard-client/src/hooks/socket.ts
@@ -1,7 +1,6 @@
 import {io, Socket} from "socket.io-client"
 
-
-const URL = process.env.REACT_APP_API_URL
+const URL = import.meta.env.VITE_API_URL
 export const socket : Socket = io(URL, {
     transports: ['polling','websocket']
 });


### PR DESCRIPTION
Due to my previous misunderstanding of environment variables in React I was trying to access the backend URL via ``process.env....``. This has since been changed to use Vite's ``import.meta.env...``